### PR TITLE
Change `find_cameras()` to search for `/dev/cam*` paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,6 @@ outputs/
 
 # Dev folders
 .cache/*
+
+# calibration
+calibration/

--- a/src/lerobot/cameras/opencv/camera_opencv.py
+++ b/src/lerobot/cameras/opencv/camera_opencv.py
@@ -259,7 +259,9 @@ class OpenCVCamera(Camera):
         found_cameras_info = []
 
         if platform.system() == "Linux":
-            possible_paths = sorted(Path("/dev").glob("video*"), key=lambda p: p.name)
+            # Assuming all cameras are already mapped via udev rules to /dev/cam*
+            # eg. /dev/cam_front, /dev/cam_right, etc.
+            possible_paths = sorted(Path("/dev").glob("cam*"), key=lambda p: p.name)
             targets_to_scan = [str(p) for p in possible_paths]
         else:
             targets_to_scan = list(range(MAX_OPENCV_INDEX))


### PR DESCRIPTION
## What this does

- In my setup I have created udev rules for the cameras so that they are always symlinked to `/dev/cam_front`, `/dev/cam_top`, `/dev/cam_wrist`. Updating the `find_cameras()` method to look for cameras using these names.
- Plus, updated gitignore to ignore the calibration folder...

## How it was tested
Using the following udev rules:

```
SUBSYSTEM=="video4linux", ATTRS{idVendor}=="3443", ATTRS{idProduct}=="60bb", ENV{ID_PATH}=="pci-0000:06:00.1-usb-0:4:1.0", KERNEL=="video[02468]*", SYMLINK+="cam_top", MODE="0666", GROUP="video"

SUBSYSTEM=="video4linux", ATTRS{idVendor}=="3443", ATTRS{idProduct}=="60bb", ENV{ID_PATH}=="pci-0000:0b:00.3-usb-0:1:1.0", KERNEL=="video[02468]*", SYMLINK+="cam_front", MODE="0666", GROUP="video"

SUBSYSTEM=="video4linux", ATTRS{idVendor}=="05a3", ATTRS{idProduct}=="9230", ENV{ID_PATH}=="pci-0000:06:00.1-usb-0:2:1.0", KERNEL=="video[02468]*", SYMLINK+="cam_wrist", MODE="0666", GROUP="video"
```

## How to checkout & try? (for the reviewer)

- Run `bringup/identify_cameras.sh` (this is in my SO101 repo: https://github.com/sherrychen1120/so101_bench) to get recommended udev rules.
- Follow the instructions from that script to restart `udevadm`
- Now run `lerobot-find-cameras opencv`