### PR TITLE
Allow passing in camera config as path to JSON file

### DIFF
--- a/src/lerobot/cameras/opencv/camera_opencv.py
+++ b/src/lerobot/cameras/opencv/camera_opencv.py
@@ -235,12 +235,9 @@ class OpenCVCamera(Camera):
             desired_value = getattr(self.config, config_name, None)
             if desired_value is not None:
                 self.videocapture.set(cap_prop, desired_value)
-        
-        # Debug print to confirm camera controls are set.
-        for config_name, cap_prop in CONFIG_NAME_TO_CAP_PROP.items():
+            
             value = self.videocapture.get(cap_prop)
-            desired_value = getattr(self.config, config_name, None)
-            if desired_value is not None and value != desired_value:
+            if desired_value is not None and not np.isclose(value, desired_value):
                 raise ValueError(
                     f"[{self.config.index_or_path}] Failed to set {config_name}: "
                     f"desired={desired_value}, actual={value}"

--- a/src/lerobot/cameras/opencv/camera_opencv.py
+++ b/src/lerobot/cameras/opencv/camera_opencv.py
@@ -21,6 +21,7 @@ import math
 import os
 import platform
 import time
+from dataclasses import fields
 from pathlib import Path
 from threading import Event, Lock, Thread
 from typing import Any
@@ -46,6 +47,19 @@ MAX_OPENCV_INDEX = 60
 
 logger = logging.getLogger(__name__)
 
+CONFIG_NAME_TO_CAP_PROP = {
+    "auto_exposure": cv2.CAP_PROP_AUTO_EXPOSURE,
+    "exposure": cv2.CAP_PROP_EXPOSURE,
+    "gain": cv2.CAP_PROP_GAIN,
+    "auto_white_balance": cv2.CAP_PROP_AUTO_WB,
+    "white_balance_temperature": cv2.CAP_PROP_WB_TEMPERATURE,
+    "autofocus": cv2.CAP_PROP_AUTOFOCUS,
+    "brightness": cv2.CAP_PROP_BRIGHTNESS,
+    "contrast": cv2.CAP_PROP_CONTRAST,
+    "saturation": cv2.CAP_PROP_SATURATION,
+    "sharpness": cv2.CAP_PROP_SHARPNESS,
+    "zoom_absolute": cv2.CAP_PROP_ZOOM,
+}
 
 class OpenCVCamera(Camera):
     """
@@ -215,6 +229,22 @@ class OpenCVCamera(Camera):
                 self.capture_width, self.capture_height = default_width, default_height
         else:
             self._validate_width_and_height()
+        
+        # Configure camera controls.
+        for config_name, cap_prop in CONFIG_NAME_TO_CAP_PROP.items():
+            desired_value = getattr(self.config, config_name, None)
+            if desired_value is not None:
+                self.videocapture.set(cap_prop, desired_value)
+        
+        # Debug print to confirm camera controls are set.
+        for config_name, cap_prop in CONFIG_NAME_TO_CAP_PROP.items():
+            value = self.videocapture.get(cap_prop)
+            desired_value = getattr(self.config, config_name, None)
+            if desired_value is not None and value != desired_value:
+                raise ValueError(
+                    f"[{self.config.index_or_path}] Failed to set {config_name}: "
+                    f"desired={desired_value}, actual={value}"
+                )
 
     def _validate_fps(self) -> None:
         """Validates and sets the camera's frames per second (FPS)."""

--- a/src/lerobot/cameras/opencv/configuration_opencv.py
+++ b/src/lerobot/cameras/opencv/configuration_opencv.py
@@ -56,6 +56,19 @@ class OpenCVCameraConfig(CameraConfig):
     rotation: Cv2Rotation = Cv2Rotation.NO_ROTATION
     warmup_s: int = 1
 
+    # Camera Controls
+    auto_exposure: int | None = None
+    exposure: int | None = None
+    gain: int | None = None
+    auto_white_balance: int | None = None
+    white_balance_temperature: int | None = None
+    autofocus: bool | None = None
+    brightness: int | None = None
+    contrast: int | None = None
+    saturation: int | None = None
+    sharpness: int | None = None
+    zoom_absolute: int | None = None
+
     def __post_init__(self):
         if self.color_mode not in (ColorMode.RGB, ColorMode.BGR):
             raise ValueError(

--- a/src/lerobot/robots/config.py
+++ b/src/lerobot/robots/config.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 
 import abc
+import json
 from dataclasses import dataclass
 from pathlib import Path
 
 import draccus
 
+from lerobot.cameras.opencv.configuration_opencv import OpenCVCameraConfig
+from lerobot.cameras.realsense.configuration_realsense import RealSenseCameraConfig
 
 @dataclass(kw_only=True)
 class RobotConfig(draccus.ChoiceRegistry, abc.ABC):
@@ -25,8 +28,18 @@ class RobotConfig(draccus.ChoiceRegistry, abc.ABC):
     id: str | None = None
     # Directory to store calibration file
     calibration_dir: Path | None = None
+# Path to JSON file containing camera configurations
+    camera_configs_path: Path | None = None
 
     def __post_init__(self):
+        # Only one of cameras and camera_configs_path should be provided.
+        if len(self.cameras) > 0 and self.camera_configs_path is not None:
+            raise ValueError("Only one of cameras and camera_configs_path can be provided.")
+        
+        # Load cameras from JSON file if path is provided
+        if self.camera_configs_path is not None:
+            self._load_camera_configs_from_json()
+        
         if hasattr(self, "cameras") and self.cameras:
             for _, config in self.cameras.items():
                 for attr in ["width", "height", "fps"]:
@@ -34,6 +47,49 @@ class RobotConfig(draccus.ChoiceRegistry, abc.ABC):
                         raise ValueError(
                             f"Specifying '{attr}' is required for the camera to be used in a robot"
                         )
+
+    def _load_camera_configs_from_json(self):
+        """Load camera configurations from JSON file."""
+        
+        config_path = Path(self.camera_configs_path)
+        if not config_path.exists():
+            raise FileNotFoundError(f"Camera configuration file not found: {config_path}")
+        
+        try:
+            with open(config_path, 'r') as f:
+                cameras_config_dict = json.load(f)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON in camera configuration file {config_path}: {e}")
+        
+        if not isinstance(cameras_config_dict, dict):
+            raise ValueError(f"Camera configuration file must contain a JSON object, got {type(cameras_data).__name__}")
+        
+        # Convert JSON data to CameraConfig objects
+        cameras = {}
+        for camera_name, raw_config in cameras_config_dict.items():
+            if not isinstance(raw_config, dict):
+                raise ValueError(f"Camera '{camera_name}' configuration must be a dictionary")
+            
+            camera_type = raw_config.get("type")
+            if camera_type is None:
+                raise ValueError(f"Camera '{camera_name}' must specify a 'type'")
+            
+            # Create the appropriate camera config object based on type
+            # Remove 'type' key from config dict before passing to constructor
+            config_without_type = {k: v for k, v in raw_config.items() if k != "type"}
+            
+            if camera_type == "opencv":
+                cameras[camera_name] = OpenCVCameraConfig(**config_without_type)
+            elif camera_type == "realsense":
+                cameras[camera_name] = RealSenseCameraConfig(**config_without_type)
+            else:
+                raise ValueError(f"Unsupported camera type '{camera_type}' for camera '{camera_name}'")
+        
+        # Set the cameras attribute if it exists
+        if hasattr(self, "cameras"):
+            self.cameras = cameras
+        else:
+            raise ValueError("Robot configuration does not support cameras")
 
     @property
     def type(self) -> str:

--- a/src/lerobot/robots/config.py
+++ b/src/lerobot/robots/config.py
@@ -28,7 +28,7 @@ class RobotConfig(draccus.ChoiceRegistry, abc.ABC):
     id: str | None = None
     # Directory to store calibration file
     calibration_dir: Path | None = None
-# Path to JSON file containing camera configurations
+    # Path to JSON file containing camera configurations
     camera_configs_path: Path | None = None
 
     def __post_init__(self):

--- a/tests/cameras/example_camera_config.json
+++ b/tests/cameras/example_camera_config.json
@@ -1,0 +1,30 @@
+{
+  "left": {
+    "type": "opencv",
+    "index_or_path": 0,
+    "width": 640,
+    "height": 480,
+    "fps": 30,
+    "auto_exposure": 0,
+    "exposure": 100,
+    "gain": 100,
+    "auto_white_balance": 0,
+    "white_balance_temperature": 4000,
+    "autofocus": 0
+  },
+  "top": {
+    "type": "opencv", 
+    "index_or_path": 1,
+    "width": 640,
+    "height": 480,
+    "fps": 30
+  },
+  "right": {
+    "type": "realsense",
+    "serial_number_or_name": "dummy_serial_number",
+    "width": 640,
+    "height": 480,
+    "fps": 30,
+    "use_depth": true
+  }
+}

--- a/tests/cameras/test_camera_config.py
+++ b/tests/cameras/test_camera_config.py
@@ -1,13 +1,11 @@
-#!/usr/bin/env python3
-"""
-Test script to verify camera configuration loading from JSON file.
-"""
+#!/usr/bin/env python
 
-import sys
-import os
+# Example of running a specific test:
+# ```bash
+# pytest tests/cameras/test_camera_config.py::test_json_camera_config
+# ```
 
-# Add the lerobot path to sys.path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "third_party", "lerobot", "src"))
+import pytest
 
 from lerobot.robots.so101_follower.config_so101_follower import SO101FollowerConfig
 
@@ -26,6 +24,3 @@ def test_json_camera_config():
         print(f"  - {name}: {camera_config.type} camera ({camera_config.width}x{camera_config.height}@{camera_config.fps}fps)")
     
     print("✓ JSON camera configuration loading works!")
-
-if __name__ == "__main__":
-    test_json_camera_config()

--- a/tests/cameras/test_camera_config.py
+++ b/tests/cameras/test_camera_config.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""
+Test script to verify camera configuration loading from JSON file.
+"""
+
+import sys
+import os
+
+# Add the lerobot path to sys.path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "third_party", "lerobot", "src"))
+
+from lerobot.robots.so101_follower.config_so101_follower import SO101FollowerConfig
+
+def test_json_camera_config():
+    """Test loading camera config from JSON file."""
+    print("Testing JSON camera configuration loading...")
+    
+    # Test with JSON file
+    config = SO101FollowerConfig(
+        port="/dev/test",
+        camera_configs_path="example_camera_config.json"
+    )
+    
+    print(f"Loaded {len(config.cameras)} cameras from JSON:")
+    for name, camera_config in config.cameras.items():
+        print(f"  - {name}: {camera_config.type} camera ({camera_config.width}x{camera_config.height}@{camera_config.fps}fps)")
+    
+    print("✓ JSON camera configuration loading works!")
+
+if __name__ == "__main__":
+    test_json_camera_config()


### PR DESCRIPTION
## What this does

- Added more fine-grained OpenCV camera controls.
- Allow passing in camera_config as a path to a json file.

Example usage:
- Turn off auto-exposure and auto-white-balance of the camera in order to achieve consistent image input during training / testing.

## How it was tested
- Added unit test: `tests/cameras/test_camera_config.py`
- Tested with `teleoperate` on a setup with SO-101 follower, leader and two webcams. Both `robot.cameras` and `robot.camera_configs_path` work

## How to checkout & try? (for the reviewer)

```
python -m lerobot.teleoperate \
    --robot.type=so101_follower \
    --robot.port=<robot_port> \
    --robot.id=<robot_id> \
    --robot.camera_configs_path=<path_to_camera_configs_json> \
    --teleop.type=so101_leader \
    --teleop.port=<teleop_port> \
    --teleop.id=<teleop_id> \
    --display_data=true
```
See `tests/cameras/example_camera_config.json` for an example camera_configs_json.