### PR TITLE
Recorder improvement for `so101_bench` eval pipeline

### DIFF
--- a/src/lerobot/cameras/camera.py
+++ b/src/lerobot/cameras/camera.py
@@ -89,7 +89,7 @@ class Camera(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def read(self, color_mode: ColorMode | None = None) -> np.ndarray:
+    def read(self, color_mode: ColorMode | None = None) -> tuple[np.ndarray, float]:
         """Capture and return a single frame from the camera.
 
         Args:
@@ -97,12 +97,12 @@ class Camera(abc.ABC):
                         uses the camera's default color mode.
 
         Returns:
-            np.ndarray: Captured frame as a numpy array.
+            tuple[np.ndarray, float]: Captured frame as a numpy array and the timestamp of the frame.
         """
         pass
 
     @abc.abstractmethod
-    def async_read(self, timeout_ms: float = ...) -> np.ndarray:
+    def async_read(self, timeout_ms: float = ...) -> tuple[np.ndarray, float]:
         """Asynchronously capture and return a single frame from the camera.
 
         Args:
@@ -110,7 +110,10 @@ class Camera(abc.ABC):
                         Defaults to implementation-specific timeout.
 
         Returns:
-            np.ndarray: Captured frame as a numpy array.
+            tuple[np.ndarray, float]: Captured frame as a numpy array and the timestamp of the frame.
+        
+        TODO(sherry): Update other robot types to accept frame_timestamp as an
+        extra return value.
         """
         pass
 

--- a/src/lerobot/cameras/camera.py
+++ b/src/lerobot/cameras/camera.py
@@ -113,7 +113,7 @@ class Camera(abc.ABC):
             tuple[np.ndarray, float]: Captured frame as a numpy array and the timestamp of the frame.
         
         TODO(sherry): Update other robot types to accept frame_timestamp as an
-        extra return value.
+        extra return value. (Currently only so101_follower supports this.)
         """
         pass
 

--- a/src/lerobot/cameras/opencv/camera_opencv.py
+++ b/src/lerobot/cameras/opencv/camera_opencv.py
@@ -136,6 +136,7 @@ class OpenCVCamera(Camera):
         self.stop_event: Event | None = None
         self.frame_lock: Lock = Lock()
         self.latest_frame: np.ndarray | None = None
+        self.latest_frame_timestamp: float | None = None
         self.new_frame_event: Event = Event()
 
         self.rotation: int | None = get_cv2_rotation(config.rotation)
@@ -318,7 +319,7 @@ class OpenCVCamera(Camera):
 
         return found_cameras_info
 
-    def read(self, color_mode: ColorMode | None = None) -> np.ndarray:
+    def read(self, color_mode: ColorMode | None = None) -> tuple[np.ndarray, float]:
         """
         Reads a single frame synchronously from the camera.
 
@@ -345,7 +346,7 @@ class OpenCVCamera(Camera):
             raise DeviceNotConnectedError(f"{self} is not connected.")
 
         start_time = time.perf_counter()
-
+        frame_timestamp = time.time()
         ret, frame = self.videocapture.read()
 
         if not ret or frame is None:
@@ -356,7 +357,7 @@ class OpenCVCamera(Camera):
         read_duration_ms = (time.perf_counter() - start_time) * 1e3
         logger.debug(f"{self} read took: {read_duration_ms:.1f}ms")
 
-        return processed_frame
+        return processed_frame, frame_timestamp
 
     def _postprocess_image(self, image: np.ndarray, color_mode: ColorMode | None = None) -> np.ndarray:
         """
@@ -414,10 +415,11 @@ class OpenCVCamera(Camera):
         """
         while not self.stop_event.is_set():
             try:
-                color_image = self.read()
+                color_image, frame_timestamp = self.read()
 
                 with self.frame_lock:
                     self.latest_frame = color_image
+                    self.latest_frame_timestamp = frame_timestamp
                 self.new_frame_event.set()
 
             except DeviceNotConnectedError:
@@ -448,7 +450,7 @@ class OpenCVCamera(Camera):
         self.thread = None
         self.stop_event = None
 
-    def async_read(self, timeout_ms: float = 200) -> np.ndarray:
+    def async_read(self, timeout_ms: float = 200) -> tuple[np.ndarray, float]:
         """
         Reads the latest available frame asynchronously.
 
@@ -463,6 +465,7 @@ class OpenCVCamera(Camera):
         Returns:
             np.ndarray: The latest captured frame as a NumPy array in the format
                        (height, width, channels), processed according to configuration.
+            float: The timestamp of the frame.
 
         Raises:
             DeviceNotConnectedError: If the camera is not connected.
@@ -484,12 +487,13 @@ class OpenCVCamera(Camera):
 
         with self.frame_lock:
             frame = self.latest_frame
+            frame_timestamp = self.latest_frame_timestamp
             self.new_frame_event.clear()
 
         if frame is None:
             raise RuntimeError(f"Internal error: Event set but no frame available for {self}.")
 
-        return frame
+        return frame, frame_timestamp
 
     def disconnect(self):
         """

--- a/src/lerobot/cameras/realsense/camera_realsense.py
+++ b/src/lerobot/cameras/realsense/camera_realsense.py
@@ -133,6 +133,7 @@ class RealSenseCamera(Camera):
         self.stop_event: Event | None = None
         self.frame_lock: Lock = Lock()
         self.latest_frame: np.ndarray | None = None
+        self.latest_frame_timestamp: float | None = None
         self.new_frame_event: Event = Event()
 
         self.rotation: int | None = get_cv2_rotation(config.rotation)
@@ -351,7 +352,7 @@ class RealSenseCamera(Camera):
 
         return depth_map_processed
 
-    def read(self, color_mode: ColorMode | None = None, timeout_ms: int = 200) -> np.ndarray:
+    def read(self, color_mode: ColorMode | None = None, timeout_ms: int = 200) -> tuple[np.ndarray, float]:
         """
         Reads a single frame (color) synchronously from the camera.
 
@@ -375,6 +376,7 @@ class RealSenseCamera(Camera):
             raise DeviceNotConnectedError(f"{self} is not connected.")
 
         start_time = time.perf_counter()
+        frame_timestamp = time.time()
 
         ret, frame = self.rs_pipeline.try_wait_for_frames(timeout_ms=timeout_ms)
 
@@ -389,7 +391,7 @@ class RealSenseCamera(Camera):
         read_duration_ms = (time.perf_counter() - start_time) * 1e3
         logger.debug(f"{self} read took: {read_duration_ms:.1f}ms")
 
-        return color_image_processed
+        return color_image_processed, frame_timestamp
 
     def _postprocess_image(
         self, image: np.ndarray, color_mode: ColorMode | None = None, depth_frame: bool = False
@@ -486,7 +488,7 @@ class RealSenseCamera(Camera):
         self.stop_event = None
 
     # NOTE(Steven): Missing implementation for depth for now
-    def async_read(self, timeout_ms: float = 200) -> np.ndarray:
+    def async_read(self, timeout_ms: float = 200) -> tuple[np.ndarray, float]:
         """
         Reads the latest available frame data (color) asynchronously.
 
@@ -522,12 +524,13 @@ class RealSenseCamera(Camera):
 
         with self.frame_lock:
             frame = self.latest_frame
+            frame_timestamp = self.latest_frame_timestamp
             self.new_frame_event.clear()
 
         if frame is None:
             raise RuntimeError(f"Internal error: Event set but no frame available for {self}.")
 
-        return frame
+        return frame, frame_timestamp
 
     def disconnect(self):
         """

--- a/src/lerobot/record.py
+++ b/src/lerobot/record.py
@@ -243,6 +243,20 @@ def record_loop(
         start_loop_t = time.perf_counter()
         start_loop_timestamp = time.time()
 
+        # Call this before any other operations to ensure the event is recorded.
+        # Because events might lead to early exit of the loop.
+        if raw_recorder is not None:
+            raw_recorder.add_event(
+                frame_timestamp=start_loop_timestamp,
+                events=events,
+            )
+
+        if events["emergency_stop"]:
+            logging.warning("Emergency stop pressed! Stopping data recording...")
+            assert events["exit_early"]
+            events["exit_early"] = False
+            break
+
         if events["exit_early"]:
             events["exit_early"] = False
             break

--- a/src/lerobot/record.py
+++ b/src/lerobot/record.py
@@ -116,7 +116,9 @@ from lerobot.utils.utils import (
     log_say,
 )
 from lerobot.utils.visualization_utils import _init_rerun, log_rerun_data
+
 from so101_bench.raw_dataset_recorder import RawDatasetRecorder
+from so101_bench.task_configurator import TaskConfigurator
 
 @dataclass
 class DatasetRecordConfig:
@@ -154,16 +156,28 @@ class DatasetRecordConfig:
     # Number of episodes to record before batch encoding videos
     # Set to 1 for immediate encoding (default behavior), or higher for batched encoding
     video_encoding_batch_size: int = 1
+    
     # Enable raw dataset format recording alongside LeRobot format
     save_raw_format: bool = False
     # Root directory for raw format datasets (defaults to root if not specified)
     raw_format_root: str | Path | None = None
     # Save videos in raw format
     raw_format_videos: bool = True
+    # Directory containing task specifications and templates
+    tasks_dir: str | Path | None = None
+    # Name of the specific task to use for configuration
+    task_name: str | None = None
 
     def __post_init__(self):
         if self.single_task is None:
             raise ValueError("You need to provide a task as argument in `single_task`.")
+        
+        # Validate task configuration options
+        if self.save_raw_format:
+            if (self.tasks_dir is None) != (self.task_name is None):
+                raise ValueError("Both tasks_dir and task_name must be provided together or neither should be provided.")
+        elif self.tasks_dir is not None or self.task_name is not None:
+            raise ValueError("tasks_dir and task_name can only be used when save_raw_format=True.")
 
 
 @dataclass
@@ -342,8 +356,9 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
 
     # Initialize raw dataset recorder if enabled
     raw_recorder = None
+    task_configurator = None
     if cfg.dataset.save_raw_format:
-        raw_root = cfg.dataset.raw_format_root or cfg.dataset.root
+        raw_root = cfg.dataset.raw_format_root
         # Extract dataset name from repo_id (e.g., "user/dataset" -> "dataset")
         dataset_name = cfg.dataset.repo_id.split("/")[-1]
         raw_recorder = RawDatasetRecorder(
@@ -358,6 +373,11 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
             image_writer_processes=cfg.dataset.num_image_writer_processes,
             image_writer_threads=cfg.dataset.num_image_writer_threads_per_camera,
         )
+        if cfg.dataset.tasks_dir is not None and cfg.dataset.task_name is not None:
+            task_configurator = TaskConfigurator(
+                tasks_dir=Path(cfg.dataset.tasks_dir),
+                task_name=cfg.dataset.task_name,
+            )
 
     if cfg.resume:
         dataset = LeRobotDataset(
@@ -393,13 +413,27 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
     robot.connect()
     if teleop is not None:
         teleop.connect()
-
-    listener, events = init_keyboard_listener()
-
+    
+    # TODO(sherry): Factor out KeyboardEventListener to a separate class
+    # that manages `events`` and controls the keyboard listener.
+    events = {
+        "stop_recording": False,
+    }
     with VideoEncodingManager(dataset):
         recorded_episodes = 0
         while recorded_episodes < cfg.dataset.num_episodes and not events["stop_recording"]:
             log_say(f"Recording episode {dataset.num_episodes}", cfg.play_sounds)
+            
+            # Get task configuration if enabled
+            task_config = None
+            if task_configurator is not None:
+                try:
+                    task_config = task_configurator.get_task_config_from_user()
+                except Exception as e:
+                    logging.error(f"Error loading task configuration: {e}")
+                    log_say(f"Error with task configuration: {e}", cfg.play_sounds)
+                    # Continue without task config
+                    task_config = None
             
             # Start raw recording episode if enabled
             if raw_recorder is not None:
@@ -417,7 +451,11 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
                     policy_info=policy_info,
                     leader_id=getattr(cfg.teleop, "id", None) if cfg.teleop else None,
                     follower_id=getattr(cfg.robot, "id", None),
+                    task_config=task_config,
                 )
+            
+            # Starting keyboard listener right before the record loop
+            listener, events = init_keyboard_listener()
             
             record_loop(
                 robot=robot,
@@ -460,6 +498,10 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
                     raw_recorder.frame_count = 0
                 continue
 
+            # Stop keyboard listener at the end of each episode.
+            if not is_headless() and listener is not None:
+                listener.stop()
+
             dataset.save_episode()
             
             # Save raw episode if enabled
@@ -477,7 +519,6 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
     if not is_headless() and listener is not None:
         listener.stop()
 
-    # Cleanup raw recorder
     if raw_recorder is not None:
         raw_recorder.cleanup()
 

--- a/src/lerobot/record.py
+++ b/src/lerobot/record.py
@@ -235,12 +235,13 @@ def record_loop(
     if policy is not None:
         policy.reset()
 
-    timestamp = 0
+    actual_duration_s = 0
     sequence_number = 0
     start_episode_t = time.perf_counter()
-    while timestamp < control_time_s:
+    while actual_duration_s < control_time_s:
         sequence_number += 1
         start_loop_t = time.perf_counter()
+        start_loop_timestamp = time.time()
 
         if events["exit_early"]:
             events["exit_early"] = False
@@ -249,7 +250,8 @@ def record_loop(
         observation = robot.get_observation()
 
         if policy is not None or dataset is not None:
-            observation_frame = build_dataset_frame(dataset.features, observation, prefix="observation")
+            observation_no_timestamp = {k: v for k, v in observation.items() if not k.endswith("_timestamp")}
+            observation_frame = build_dataset_frame(dataset.features, observation_no_timestamp, prefix="observation")
 
         if policy is not None:
             action_values = predict_action(
@@ -285,16 +287,19 @@ def record_loop(
         sent_action = robot.send_action(action)
 
         if dataset is not None:
-            action_frame = build_dataset_frame(dataset.features, sent_action, prefix="action")
+            sent_action_no_timestamp = {k: v for k, v in sent_action.items() if k != "action_timestamp"}
+            action_frame = build_dataset_frame(dataset.features, sent_action_no_timestamp, prefix="action")
             frame = {**observation_frame, **action_frame}
             dataset.add_frame(frame, task=single_task)
 
         # Add frame to raw recorder if enabled
+        # Use start_loop_timestamp as the frame timestamp as that's controlled to run
+        # at as close to fps as possible.
         if raw_recorder is not None:
             raw_recorder.add_frame(
                 observation=deepcopy(observation),
                 action=sent_action,
-                timestamp=start_loop_t,
+                frame_timestamp=start_loop_timestamp,
                 sequence_number=sequence_number,
             )
 
@@ -304,7 +309,7 @@ def record_loop(
         dt_s = time.perf_counter() - start_loop_t
         busy_wait(1 / fps - dt_s)
 
-        timestamp = time.perf_counter() - start_episode_t
+        actual_duration_s = time.perf_counter() - start_episode_t
 
 
 @parser.wrap()

--- a/src/lerobot/robots/so101_follower/so101_follower.py
+++ b/src/lerobot/robots/so101_follower/so101_follower.py
@@ -164,20 +164,32 @@ class SO101Follower(Robot):
             print(f"'{motor}' motor id set to {self.bus.motors[motor].id}")
 
     def get_observation(self) -> dict[str, Any]:
+        f"""
+        Returns:
+            dict[str, Any]: A flat dictionary representing the robot's current sensory state. Including:
+                - The timestamp of the robot state, with the key "robot_state_timestamp"
+                - Joint posiitons, with keys "<joint_name>.pos"
+                - The timestamp of each camera, with the key "<camera_name>_timestamp"
+                - The image from each camera, with the key "<camera_name>"
+        """
         if not self.is_connected:
             raise DeviceNotConnectedError(f"{self} is not connected.")
 
         # Read arm position
         start = time.perf_counter()
         obs_dict = self.bus.sync_read("Present_Position")
+        robot_state_timestamp = time.time()
         obs_dict = {f"{motor}.pos": val for motor, val in obs_dict.items()}
+        obs_dict["robot_state_timestamp"] = robot_state_timestamp
         dt_ms = (time.perf_counter() - start) * 1e3
         logger.debug(f"{self} read state: {dt_ms:.1f}ms")
 
         # Capture images from cameras
         for cam_key, cam in self.cameras.items():
             start = time.perf_counter()
-            obs_dict[cam_key] = cam.async_read()
+            img, cam_timestamp = cam.async_read()
+            obs_dict[cam_key] = img
+            obs_dict[f"{cam_key}_timestamp"] = cam_timestamp
             dt_ms = (time.perf_counter() - start) * 1e3
             logger.debug(f"{self} read {cam_key}: {dt_ms:.1f}ms")
 
@@ -195,6 +207,7 @@ class SO101Follower(Robot):
 
         Returns:
             the action sent to the motors, potentially clipped.
+            The dictionary also contains the timestamp when the action was sent, with the key "action_timestamp".
         """
         if not self.is_connected:
             raise DeviceNotConnectedError(f"{self} is not connected.")
@@ -210,7 +223,10 @@ class SO101Follower(Robot):
 
         # Send goal position to the arm
         self.bus.sync_write("Goal_Position", goal_pos)
-        return {f"{motor}.pos": val for motor, val in goal_pos.items()}
+        action_timestamp = time.time()
+        action_sent = {f"{motor}.pos": val for motor, val in goal_pos.items()}
+        action_sent["action_timestamp"] = action_timestamp
+        return action_sent
 
     def disconnect(self):
         if not self.is_connected:

--- a/src/lerobot/robots/so101_follower/so101_follower.py
+++ b/src/lerobot/robots/so101_follower/so101_follower.py
@@ -164,7 +164,7 @@ class SO101Follower(Robot):
             print(f"'{motor}' motor id set to {self.bus.motors[motor].id}")
 
     def get_observation(self) -> dict[str, Any]:
-        f"""
+        """
         Returns:
             dict[str, Any]: A flat dictionary representing the robot's current sensory state. Including:
                 - The timestamp of the robot state, with the key "robot_state_timestamp"

--- a/src/lerobot/utils/control_utils.py
+++ b/src/lerobot/utils/control_utils.py
@@ -143,6 +143,7 @@ def init_keyboard_listener():
     events["exit_early"] = False
     events["rerecord_episode"] = False
     events["stop_recording"] = False
+    events["emergency_stop"] = False
 
     if is_headless():
         logging.warning(
@@ -165,6 +166,11 @@ def init_keyboard_listener():
                 events["exit_early"] = True
             elif key == keyboard.Key.esc:
                 print("Escape key pressed. Stopping data recording...")
+                events["stop_recording"] = True
+                events["exit_early"] = True
+            elif key == keyboard.Key.space:
+                print("Space bar pressed. Emergency stop! Stopping data recording...")
+                events["emergency_stop"] = True
                 events["stop_recording"] = True
                 events["exit_early"] = True
         except Exception as e:


### PR DESCRIPTION
## What this does
Recorder improvements (to support the eval pipeline introduced in https://github.com/sherrychen1120/so101_bench/pull/3)
- task_spec and task_config: Specified an interface to define task variations within each episode.
- Frame latency data and metrics (only `so101_follower` supports this)
- emergency-stop (space bar) and safety abort metrics

## How it was tested
Record a dataset with record.py.
- [x] with or without task_config
- [x] contains frame latency data
- [x] end episodes with e-stop. The event was logged correctly.

## How to checkout & try? (for the reviewer)
```bash
python -m lerobot.record \
    --robot.type=so101_follower \
    --robot.port=/dev/so101_follower \
    --robot.id=dum_e_follower \
    # To specify camera configs
    --robot.camera_configs_path=/home/melon/sherry/so101_bench/bringup/camera_configs.json \
    --robot.calibration_dir=/home/melon/sherry/lerobot/calibration/robots/so101_follower \
    --teleop.type=so101_leader \
    --teleop.port=/dev/so101_leader \
    --teleop.calibration_dir=/home/melon/sherry/lerobot/calibration/teleoperators/so101_leader \
    --teleop.id=dum_e_leader \
    --display_data=true \
    --dataset.repo_id=${HF_USER}/2025-08-25_test \
    --dataset.push_to_hub=false \
    --dataset.private=true \
    --dataset.reset_time_s=5 \
    --dataset.num_episodes=1 \
    --dataset.single_task="Grab the block and put it in the container." \
    --resume=true \
    # To save the "raw dataset" used by so101_bench eval pipeline
    --dataset.save_raw_format=true \
    --dataset.raw_format_root=/home/melon/sherry/so101_bench/datasets/recordings/ \
    --dataset.raw_format_videos=true \
    # To specify a task_config for the dataset
    --dataset.tasks_dir=/home/melon/sherry/so101_bench/datasets/tasks \
    --dataset.task_name=pick_and_place_block
```