### PR TITLE
🐛 Update `cam.read()` in `find_camera`

### DIFF
--- a/src/lerobot/find_cameras.py
+++ b/src/lerobot/find_cameras.py
@@ -199,7 +199,7 @@ def process_camera_image(
     cam_id_str = str(meta.get("id", "unknown"))
 
     try:
-        image_data = cam.read()
+        image_data, _ = cam.read()
 
         return save_image(
             image_data,


### PR DESCRIPTION
## What this does
`cam.read()` returns a tuple. This broke find_camera.py

## How it was tested
`python -m lerobot.find_cameras opencv` worked