### PR TITLE
Use OpenCV imshow for teleop viz

### DIFF
--- a/src/lerobot/teleoperate.py
+++ b/src/lerobot/teleoperate.py
@@ -84,7 +84,7 @@ from lerobot.teleoperators import (  # noqa: F401
 )
 from lerobot.utils.robot_utils import busy_wait
 from lerobot.utils.utils import init_logging, move_cursor_up
-from lerobot.utils.visualization_utils import _init_rerun, log_rerun_data
+from lerobot.utils.visualization_utils import _init_rerun, log_rerun_data, visualize_camera_feeds
 
 
 @dataclass
@@ -109,7 +109,8 @@ def teleop_loop(
         action = teleop.get_action()
         if display_data:
             observation = robot.get_observation()
-            log_rerun_data(observation, action)
+            visualize_camera_feeds(observation)
+            # log_rerun_data(observation, action)
 
         robot.send_action(action)
         dt_s = time.perf_counter() - loop_start
@@ -133,8 +134,8 @@ def teleop_loop(
 def teleoperate(cfg: TeleoperateConfig):
     init_logging()
     logging.info(pformat(asdict(cfg)))
-    if cfg.display_data:
-        _init_rerun(session_name="teleoperation")
+    # if cfg.display_data:
+    #     _init_rerun(session_name="teleoperation")
 
     teleop = make_teleoperator_from_config(cfg.teleop)
     robot = make_robot_from_config(cfg.robot)
@@ -148,7 +149,8 @@ def teleoperate(cfg: TeleoperateConfig):
         pass
     finally:
         if cfg.display_data:
-            rr.rerun_shutdown()
+            # rr.rerun_shutdown()
+            cv2.destroyAllWindows()
         teleop.disconnect()
         robot.disconnect()
 

--- a/src/lerobot/utils/visualization_utils.py
+++ b/src/lerobot/utils/visualization_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import cv2
 from typing import Any
 
 import numpy as np
@@ -44,3 +45,48 @@ def log_rerun_data(observation: dict[str | Any], action: dict[str | Any]):
         elif isinstance(val, np.ndarray):
             for i, v in enumerate(val):
                 rr.log(f"action.{act}_{i}", rr.Scalar(float(v)))
+
+def visualize_camera_feeds(observation: dict[str, Any]):
+    for cam_key, cam_val in observation.items():
+        if not cam_key.startswith("cam_"):
+            continue
+        if cam_key.endswith("_timestamp"):
+            continue
+        
+        # Skip if not a valid image array
+        if not isinstance(cam_val, np.ndarray):
+            print(f"  Skipping {cam_key}: not a numpy array")
+            continue
+        
+        if len(cam_val.shape) != 3:
+            print(f"  Skipping {cam_key}: invalid shape {cam_val.shape}")
+            continue
+        
+        # Convert image format if needed
+        display_img = cam_val.copy()
+        
+        # Handle different data types and ranges
+        if cam_val.dtype == np.float32 or cam_val.dtype == np.float64:
+            if cam_val.max() <= 1.0:
+                # Assume normalized [0,1] range, convert to [0,255]
+                display_img = (display_img * 255).astype(np.uint8)
+            else:
+                # Assume already in [0,255] range but float
+                display_img = display_img.astype(np.uint8)
+        
+        # Convert RGB to BGR for OpenCV (if needed)
+        if display_img.shape[2] == 3:
+            # OpenCV expects BGR, but many cameras provide RGB
+            display_img = cv2.cvtColor(display_img, cv2.COLOR_RGB2BGR)
+        
+        # Modify image stream to match teleoperator POV.
+        if cam_key == "cam_top":
+            display_img = cv2.rotate(display_img, cv2.ROTATE_90_CLOCKWISE)
+        elif cam_key == "cam_front":
+            display_img = cv2.flip(display_img, 1)
+        
+        cv2.imshow(cam_key, display_img)
+    
+    # Process OpenCV events to update display windows
+    cv2.waitKey(1)
+        

--- a/src/lerobot/utils/visualization_utils.py
+++ b/src/lerobot/utils/visualization_utils.py
@@ -80,6 +80,7 @@ def visualize_camera_feeds(observation: dict[str, Any]):
             display_img = cv2.cvtColor(display_img, cv2.COLOR_RGB2BGR)
         
         # Modify image stream to match teleoperator POV.
+        # TODO(sherry): Make this configurable in RecordConfig.
         if cam_key == "cam_top":
             display_img = cv2.rotate(display_img, cv2.ROTATE_90_CLOCKWISE)
         elif cam_key == "cam_front":
@@ -89,4 +90,3 @@ def visualize_camera_feeds(observation: dict[str, Any]):
     
     # Process OpenCV events to update display windows
     cv2.waitKey(1)
-        


### PR DESCRIPTION
## What this does

Use OpenCV images instead of rerun for teleop viz. This enables publishing images from the operator's POV and makes teleop significantly easier

## How it was tested
Tested on my setup using the teleop script.
<img width="1164" height="787" alt="image" src="https://github.com/user-attachments/assets/1e264959-0a73-4735-be65-07ac3ae1cfcd" />

## How to checkout & try? (for the reviewer)
use `--display=true` when running teleop